### PR TITLE
This resolves a issue with the crypto module getting undefined symbol

### DIFF
--- a/SOURCES/python-2.7.1-config.patch
+++ b/SOURCES/python-2.7.1-config.patch
@@ -102,7 +102,7 @@
  # First, look at Setup.config; configure may have set this for you.
  
 -#crypt cryptmodule.c # -lcrypt	# crypt(3); needs -lcrypt on some systems
-+crypt cryptmodule.c # -lcrypt	# crypt(3); needs -lcrypt on some systems
++crypt cryptmodule.c -lcrypt # crypt(3); needs -lcrypt on some systems
  
  
  # Some more UNIX dependent modules -- off by default, since these

--- a/SPECS/python27.spec
+++ b/SPECS/python27.spec
@@ -133,7 +133,7 @@ Summary: An interpreted, interactive, object-oriented programming language
 Name: %{python}
 # Remember to also rebase python-docs when changing this:
 Version: 2.7.6
-Release: 1.ius%{?dist}
+Release: 2.ius%{?dist}
 License: Python
 Group: Development/Languages
 Requires: %{python}-libs%{?_isa} = %{version}-%{release}
@@ -2020,6 +2020,10 @@ rm -fr %{buildroot}
 # ======================================================
 
 %changelog
+* Mon May 19 2014 Jeffrey Ness <jeffrey.ness@rackspace.com> - 2.7.6-2.ius
+- Resolve issue with crypt module and undefined symbol
+  https://bugs.launchpad.net/ius/+bug/1320912
+
 * Mon Nov 11 2013 Ben Harper <ben.harper@rackspace.com> - 2.7.6-1.ius
 - Latest sources from upstream
 - updated Patch102 and Patch136


### PR DESCRIPTION
This bug has been reported on the IUS Community Bug Tracker:
https://bugs.launchpad.net/ius/+bug/1320912

Applied change and built. Issue not longer is reported:

```
# python2.7
Python 2.7.6 (default, May 19 2014, 11:12:03)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import crypt
```
